### PR TITLE
[FIXES JENKINS-14951] Set environment on matrix parent build

### DIFF
--- a/src/main/java/com/lookout/jenkins/EnvironmentScript.java
+++ b/src/main/java/com/lookout/jenkins/EnvironmentScript.java
@@ -202,6 +202,7 @@ public class EnvironmentScript extends BuildWrapper implements MatrixAggregatabl
 				}
 
 				build.addAction(new PersistedEnvironment(env));
+				build.getEnvironments().add(env);
 				return true;
 			}
 		};


### PR DESCRIPTION
If the build is a MatrixBuild, build wrappers are not invoked for the
parent, only for the individual MatrixRuns. In order for the environment
variables to be available to the parent (e.g. for post-build steps), we
must inject the environment into the parent directly during the aggregator
startBuild().