### PR TITLE
Set the expected encoding of script output to UTF-8.

### DIFF
--- a/src/main/java/com/lookout/jenkins/EnvironmentScript.java
+++ b/src/main/java/com/lookout/jenkins/EnvironmentScript.java
@@ -20,6 +20,7 @@ import hudson.tasks.Shell;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -120,9 +121,10 @@ public class EnvironmentScript extends BuildWrapper implements MatrixAggregatabl
 
 		// Pass the output of the command to the Properties loader.
 		ByteArrayInputStream propertiesInput = new ByteArrayInputStream(commandOutput.toByteArray());
+		InputStreamReader propertiesInputReader = new InputStreamReader(propertiesInput, "UTF-8");
 		Properties properties = new Properties();
 		try {
-			properties.load(propertiesInput);
+			properties.load(propertiesInputReader);
 		} catch (IOException e) {
 			Util.displayIOException(e, listener);
 			e.printStackTrace(listener.fatalError(Messages.EnvironmentScriptWrapper_UnableToParseScriptOutput()));

--- a/src/main/webapp/help-script.html
+++ b/src/main/webapp/help-script.html
@@ -6,6 +6,7 @@
     <ul>
       <li>If the script fails (returns a non-zero exit status), the build is failed.</li>
       <li>If it succeeds, the output is expected to be lines of <tt>KEY=VALUE</tt> pairs that will be injected into the environment variables. The output is parsed using <a href="http://docs.oracle.com/javase/6/docs/api/java/util/Properties.html#load(java.io.Reader)">java.util.Properties</a>.</li>
+      <li>The output is expected to be UTF-8 encoded.</li>
     </ul>
   </p>
 

--- a/src/test/java/com/lookout/jenkins/EnvironmentScriptTest.java
+++ b/src/test/java/com/lookout/jenkins/EnvironmentScriptTest.java
@@ -44,6 +44,9 @@ public class EnvironmentScriptTest extends HudsonTestCase {
 		"#!/bin/cat\n"
 		+ "hello=world";
 
+	final static String SCRIPT_UTF8 =
+		"echo UTFstr=mąż";
+
 	public void testWithEmptyScript () throws Exception {
 		TestJob job = new TestJob("");
 		assertBuildStatusSuccess(job.project.scheduleBuild2(0).get());
@@ -102,4 +105,12 @@ public class EnvironmentScriptTest extends HudsonTestCase {
 		EnvVars vars = job.builder.getEnvVars();
 		assertEquals("world", vars.get("hello"));
 	}
+
+	public void testUTFHandling () throws Exception {
+        TestJob job = new TestJob(SCRIPT_UTF8);
+        assertBuildStatusSuccess(job.project.scheduleBuild2(0).get());
+
+        EnvVars vars = job.builder.getEnvVars();
+        assertEquals("mąż", vars.get("UTFstr"));
+    }
 }


### PR DESCRIPTION
Currently this plugin expects the output of the script to be encoded in ISO 8859-1. We can set it to the more common UTF-8 encoding by wrapping Properties input stream in an appropriate InputStreamReader.