### PR TITLE
Add support for env var ENV_SCRIPT_PLUGIN_HIDE_VALS

### DIFF
--- a/src/main/java/com/lookout/jenkins/EnvironmentScript.java
+++ b/src/main/java/com/lookout/jenkins/EnvironmentScript.java
@@ -172,8 +172,16 @@ public class EnvironmentScript extends BuildWrapper implements MatrixAggregatabl
         final Map<String, String> envAdditions = new HashMap<String, String>(), envOverrides = new HashMap<String, String>();
         for (String key : properties.stringPropertyNames()) {
             String value = properties.getProperty(key);
-            listener.getLogger().println(
-                    "[environment-script] Adding variable '" + key + "' with value '" + value + "'");
+            String l = "[environment-script] Adding variable '" + key + "'";
+
+            EnvVars envVars = new EnvVars();
+            envVars = build.getEnvironment(listener);
+
+            // if the env var ENV_SCRIPT_PLUGIN_HIDE_VALS is set, do not output the value
+            if (envVars.get("ENV_SCRIPT_PLUGIN_HIDE_VALS") == null)
+                l += " with value '" + value + "'";
+
+            listener.getLogger().println(l);
 
             if (key.indexOf('+') > 0)
                 envOverrides.put(key, value);


### PR DESCRIPTION
Hi, I'm trying to use the plugin to dynamically retrieve secrets and set them as env vars, This works perfectly, except for the secrets being displayed in cleartext in the logs.

Added a check for the presence of ENV_SCRIPT_PLUGIN_HIDE_VALS, which will suppress the output.