### PR TITLE
Fix compatibility issue with 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
             <groupId>com.github.mjdetullio.jenkins.plugins</groupId>
             <artifactId>multi-branch-project-plugin</artifactId>
             <version>0.5.1</version>
-            <optional>true</optional>
          </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Hello there, 

after upgrading to Jenkins 2.16, we were experiencing errors on every job configuration page. 

With the help of the guys in the IRC jenkins channel, we spotted that line as being the problem. The plugin is not optional, but it's required as far as we can tell :-)
